### PR TITLE
Check for sora's forked version of sequelize when shimming models

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import LRU from 'lru-cache';
 import assert from 'assert';
 import {methods} from './helper';
 
-const versionTestRegEx = /^[456]/;
+const versionTestRegEx = /^[456]|^github:soradotco\/sequelize#v4/;
 
 function mapResult(attribute, keys, options, result) {
   // Convert an array of results to an object of attribute (primary / foreign / target key) -> array of matching rows


### PR DESCRIPTION
Since we are using a forked version of sequelize, we have to check for that forked version in `dataloader-sequelize` in order to ensure that we are shimming the models correctly.

We can get rid of this once we upgrade our version of sequelize to v5 (i.e. we are no longer using a forked version of sequelize)