### PR TITLE
check for sora's forked version of sequelize when shimming models

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import LRU from 'lru-cache';
 import assert from 'assert';
 import {methods} from './helper';
 
-const versionTestRegEx = /^[456]/;
+const versionTestRegEx = /^[456]|^github:soradotco\/sequelize#v4/;
 
 function mapResult(attribute, keys, options, result) {
   // Convert an array of results to an object of attribute (primary / foreign / target key) -> array of matching rows


### PR DESCRIPTION
Since we're using a forked version of `sequelize`, we have to check for that forked version in `dataloader-sequelize` in order to ensure that we are shimming the models correctly.

We can stop relying on this forked version of `dataloader-sequelize` once we upgrade `sequelize` to v5 in the `sora` repo (i.e we are no longer using a forked version of `sequelize`)